### PR TITLE
Capture complete property line

### DIFF
--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -160,10 +160,15 @@ class Parser
                     // Because the property type is not supported.
                     continue;
                 }
-                $propertyNameToken = $this->tokens->nextElementValueToken();
+
+                $propertyNameValues = [$this->tokens->nextElementValueToken()->getValue()];
+
+                while ($this->tokens->getNextToken() instanceof ElementValueToken) {
+                    $propertyNameValues[] = $this->tokens->nextElementValueToken()->getValue();
+                }
 
                 $node->addProperty(new Property(
-                    name: $propertyNameToken->getValue(),
+                    name: implode(' ', $propertyNameValues),
                     visibility: (string) $currentToken
                 ));
             }

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -51,15 +51,15 @@ class ParserTest extends TestCase
                     'Package' => 'Lexer/Arrow',
                     'Propaties' => [
                         [
-                            'name' => 'publicProperty',
+                            'name' => 'publicProperty : array',
                             'visibility' => 'public',
                         ],
                         [
-                            'name' => 'protectedProperty',
+                            'name' => 'protectedProperty : string',
                             'visibility' => 'protected',
                         ],
                         [
-                            'name' => 'privateProperty',
+                            'name' => 'privateProperty : string',
                             'visibility' => 'private',
                         ],
                     ],


### PR DESCRIPTION
I played around with the latest update and found an issue. This changes behaviour so it might be a breaking change. Maybe this is ok as a bug fix. You should determine whether this is a bugfix or not, but it helps me to work further:

Again my testing payload is

```puml
@startuml

hide empty methods

package Heptacom\HeptaConnect\Playground\Dataset {
    class Cap {
        + type : CapType
    }
}
@enduml
```

Before my change the property is interpreted as:

<img width="286" alt="image" src="https://user-images.githubusercontent.com/1133593/164998903-adf2b4a1-c1d2-4ae9-9270-17bc2e7569b5.png">

With my change it looks like this

<img width="285" alt="image" src="https://user-images.githubusercontent.com/1133593/164998865-a8e47656-8194-44bb-9956-edc736bfd33e.png">

It allows property lines to be captured completely when whitespace separates multiple entries. Without this change the property is not completely covered. I assume it will result in maybe some unwanted results because I am merging multiple values by a single space, which is not the exact whitespace value that has been originally be skipped by the tokenizing. I also assume that when you follow the plantuml guides to change the class body that the group separators could now be part of a property (see [here](http://www.plantuml.com/plantuml/uml/PP3DQiGm38JlUGeTMye6-W0BsqFRMozB3pq54Qk9mNz8IfPG-kwLdHO2lGmUuHb_yaKKMPSOkZ6W2Bpa_0XV7S17Nc3418kGEQ6L60C4dqZCzxq92cnswuP9gqiE9ivBiVFvRAApJvE0vebq9gw9OJWqpxXIxOYOjZqf_qfF9vDdQywVq02xx-wNz5s86sdVmzN74WXUITM63Uu1xDatZ7Ht_-UUd6CIQOCQof5iiMD43f5XWC9-HILmgBYp-wI04pKoe3JoLfJSZdbLjeMX6Dmjiwka5qgk_kqF) their example).

Please add your feedback how to process my finding.
